### PR TITLE
cleanup management crate

### DIFF
--- a/management/Cargo.toml
+++ b/management/Cargo.toml
@@ -1,9 +1,0 @@
-[package]
-name = "management"
-version = "0.1.0"
-authors = ["Davis Van Sant <davisvansant@users.noreply.github.com>"]
-edition = "2018"
-
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
-
-[dependencies]

--- a/management/src/lib.rs
+++ b/management/src/lib.rs
@@ -1,7 +1,0 @@
-#[cfg(test)]
-mod tests {
-    #[test]
-    fn it_works() {
-        assert_eq!(2 + 2, 4);
-    }
-}


### PR DESCRIPTION
This PR removes the initial management crate, with future plans to move up under the main `auth0` src directory 